### PR TITLE
Fix not considering the network & broadcast addr

### DIFF
--- a/subnettestgenerator.py
+++ b/subnettestgenerator.py
@@ -178,7 +178,7 @@ def ex_subnet_networks() -> None:
 
 def ex_subnet_hosts() -> None:
     hosts = random.randint(2,1024)
-    hostbits = math.ceil(math.log2(hosts))
+    hostbits = math.ceil(math.log2(hosts + 2))
     info = generate_network_info(generate_random_interface(30-(hostbits+1),30-(hostbits)))
     print("Starting network address: " + str(info.network) + "/" + str(info.CIDR))
     print("Maximum number of hosts on a network: " + str(hosts))


### PR DESCRIPTION
The exercise does not include network and broadcast addresses.

So if the variable `hosts` is `512`, the number of `host bits` will be `9`. While this should be `10`

Before:
```
Starting network address: 7.192.96.0/19
Maximum number of hosts on a network: 512
Number of needed host bits: 9
Total number of networks: 16
New subnet mask: /23
```

After:
```
Starting network address: 7.192.96.0/19
Maximum number of hosts on a network: 512
Number of needed host bits: 10
Total number of networks: 8
New subnet mask: /22
```